### PR TITLE
Handle redirects

### DIFF
--- a/controllers/siteauditor.ctrl.php
+++ b/controllers/siteauditor.ctrl.php
@@ -373,8 +373,8 @@ class SiteAuditorController extends Controller{
 	    $errorMsg = '';	    
 	    if ($reportUrl = $this->getProjectRandomUrl($projectId)) {
 	        $auditorComp = $this->createComponent('AuditorComponent');
-	        $auditorComp->runReport($reportUrl, $projectInfo, $this->getCountcrawledLinks($projectId));
-	        $this->set('crawledUrl', $reportUrl);	        
+	        $crawledUrl = $auditorComp->runReport($reportUrl, $projectInfo, $this->getCountcrawledLinks($projectId));
+	        $this->set('crawledUrl', $crawledUrl);	        
 	        if (!$crawlUrl = $this->getProjectRandomUrl($projectId)) {
 	            $completed = 1;
 	        } else {

--- a/controllers/siteauditor.ctrl.php
+++ b/controllers/siteauditor.ctrl.php
@@ -378,7 +378,7 @@ class SiteAuditorController extends Controller{
 	        if (!$crawlUrl = $this->getProjectRandomUrl($projectId)) {
 	            $completed = 1;
 	        } else {
-	            if (!$this->cron) updateJsLocation('crawling_url', $reportUrl);
+	            if (!$this->cron) updateJsLocation('crawling_url', $crawledUrl);
 	        }	        
 	    } else {
 	        $completed = 1;
@@ -395,7 +395,7 @@ class SiteAuditorController extends Controller{
     	    $this->set('projectInfo', $projectInfo);
     	    $this->render('siteauditor/runproject');
 	    } else {
-	        return $reportUrl;
+	        return $crawledUrl;
 	    }
 	}
     

--- a/libs/spider.class.php
+++ b/libs/spider.class.php
@@ -29,6 +29,7 @@ class Spider{
 	var $_CURLOPT_FAILONERROR = false;	
 	var $_CURLOPT_FOLLOWLOCATION = true;	
 	var $_CURLOPT_RETURNTRANSFER = true;	
+	var $_CURLOPT_MAXREDIRS = 4; //Don't get caught in redirect loop
 	var $_CURLOPT_TIMEOUT = 15;	
 	var $_CURLOPT_POST = true;
 	var $_CURLOPT_POSTFIELDS = null;
@@ -42,7 +43,8 @@ class Spider{
 	var $_CURLOPT_HEADER = 0;
 	var $_CURL_HTTPHEADER = array();
 	var $userAgentList = array();
-
+	var $effectiveUrl = null;
+	
 	# spider constructor
 	function Spider()	{			
 		$this -> _CURLOPT_COOKIEJAR = SP_TMPPATH.'/'.$this -> _CURLOPT_COOKIEJAR;
@@ -262,6 +264,7 @@ class Spider{
 		
 		curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_URL , $url );
 		curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_FAILONERROR , $this -> _CURLOPT_FAILONERROR );
+		curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_MAXREDIRS , $this -> _CURLOPT_MAXREDIRS );
 		@curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_FOLLOWLOCATION , $this -> _CURLOPT_FOLLOWLOCATION );
 		curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_RETURNTRANSFER , $this -> _CURLOPT_RETURNTRANSFER );
 		curl_setopt( $this -> _CURL_RESOURCE , CURLOPT_TIMEOUT , $this -> _CURLOPT_TIMEOUT );
@@ -316,11 +319,13 @@ class Spider{
 		$ret['error'] = curl_errno( $this -> _CURL_RESOURCE );
 		$ret['errmsg'] = curl_error( $this -> _CURL_RESOURCE );
 		
+		$this->effectiveUrl = curl_getinfo($this -> _CURL_RESOURCE, CURLINFO_EFFECTIVE_URL);
+		
 		// update crawl log in database for future reference
 		if ($logCrawl) {
 			$crawlLogCtrl = new CrawlLogController();
 			$crawlInfo['crawl_status'] = $ret['error'] ? 0 : 1;
-			$crawlInfo['ref_id'] = $crawlInfo['crawl_link'] = addslashes($url);
+			$crawlInfo['ref_id'] = $crawlInfo['crawl_link'] = addslashes($this->effectiveUrl);
 			$crawlInfo['crawl_referer'] = addslashes($this-> _CURLOPT_REFERER);
 			$crawlInfo['crawl_cookie'] = addslashes($this -> _CURLOPT_COOKIE);
 			$crawlInfo['crawl_post_fields'] = addslashes($this -> _CURLOPT_POSTFIELDS);
@@ -403,13 +408,15 @@ class Spider{
 	}
 	
 	// function to get the header of url
-    public static function getHeader($url){
+  public static function getHeader($url, $followRedirects = true){
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, SP_USER_AGENT);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		if($followRedirects){
+			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		}
 		curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
 		
 		// Only calling the head
@@ -429,6 +436,17 @@ class Spider{
 	    } else {
 	        return false; 
 	    }
+	}
+	
+	// function to check whether link is a redirect
+	public static function isLinkRedirect($url) {
+			$followRedirects = false; //don't follow with cURL as we need that info.
+			$header = $this->getHeader($url, $followRedirects);
+			if (stristr($header, '301 Moved Permanently') || stristr($header, '308 Permanent Redirect')) {
+					return true;
+			} else {
+					return false;
+			}
 	}
 }
 ?>


### PR DESCRIPTION
Update to fix a loop created when the project URL is configured to a value that
doesn’t match the effective crawled URL (i.e.: www. in one spot and no
www in the other).